### PR TITLE
Associate Characters and Scenarios

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -67,7 +67,7 @@ class ScenariosController < ApplicationController
     @scenario = Scenario.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the internet, only allow the white list through.
   def scenario_params
     params.require(:scenario).permit(:name, character_ids: [])
   end

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -62,13 +62,13 @@ class ScenariosController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_scenario
-      @scenario = Scenario.find(params[:id])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_scenario
+    @scenario = Scenario.find(params[:id])
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def scenario_params
-      params.require(:scenario).permit(:name, character_ids: [])
-    end
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def scenario_params
+    params.require(:scenario).permit(:name, character_ids: [])
+  end
 end

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -69,6 +69,6 @@ class ScenariosController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def scenario_params
-      params.require(:scenario).permit(:name)
+      params.require(:scenario).permit(:name, character_ids: [])
     end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -9,6 +9,10 @@ class Character < ApplicationRecord
 
   scope :active, -> { where(state: 'active') }
 
+  def name_and_version
+    "#{display_name} #{version}"
+  end
+
   def deactivate
     update(state: 'inactive')
   end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -3,6 +3,7 @@ class Character < ApplicationRecord
   has_many :likes
   belongs_to :previous_character, class_name: 'Character', optional: true
   has_one :next_character, class_name: 'Character', foreign_key: :previous_character_id
+  has_and_belongs_to_many :scenario
 
   has_one_attached :avatar
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -3,7 +3,7 @@ class Character < ApplicationRecord
   has_many :likes
   belongs_to :previous_character, class_name: 'Character', optional: true
   has_one :next_character, class_name: 'Character', foreign_key: :previous_character_id
-  has_and_belongs_to_many :scenario
+  has_and_belongs_to_many :scenarios
 
   has_one_attached :avatar
 

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -1,4 +1,5 @@
 class Scenario < ApplicationRecord
     has_many :pixes
+    has_and_belongs_to_many :characters
     validates :name, uniqueness: true
 end

--- a/app/views/scenarios/_form.html.erb
+++ b/app/views/scenarios/_form.html.erb
@@ -16,6 +16,11 @@
     <%= form.text_field :name, class: 'form-control' %>
   </div>
 
+  <div class="field">
+    <%= form.label :attending_characters %>
+    <%= form.collection_select :character_ids, Character.all, :id, :name_and_version, {}, multiple: true, class: 'form-control' %>
+  </div>
+
   <div class="actions">
     <%= form.submit 'Save', class: 'btn' %>
   </div>

--- a/app/views/scenarios/_form.html.erb
+++ b/app/views/scenarios/_form.html.erb
@@ -18,7 +18,14 @@
 
   <div class="field">
     <%= form.label :attending_characters %>
-    <%= form.collection_select :character_ids, Character.all, :id, :name_and_version, {}, multiple: true, class: 'form-control' %>
+    <%= form.collection_check_boxes :character_ids, Character.all, :id, :itself do |m| %>
+      <div class="mb-2">
+        <%= m.check_box(class: 'form-control col-1 d-inline-block align-bottom') %>
+        <div class="col-8 d-inline-block">
+          <%= render 'characters/header', character: Character.find_by(id: m.value) %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
   <div class="actions">

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -15,7 +15,7 @@
     <%= f.hidden_field :scenario_id, value: @scenario.id %>
     <div class="form-row">
       <div class="col-3">
-        <%= f.collection_select :character_id, Character.all, :id, :display_name, {}, class: 'form-control' %>
+        <%= f.collection_select :character_id, @scenario.characters, :id, :display_name, {}, class: 'form-control' %>
       </div>
       <div class="col-8">
         <%= f.text_field :msg, class: 'form-control' %>

--- a/db/migrate/20181116234811_create_join_table_for_characters_and_scenarios.rb
+++ b/db/migrate/20181116234811_create_join_table_for_characters_and_scenarios.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableForCharactersAndScenarios < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :characters, :scenarios do |t|
+      t.index :character_id
+      t.index :scenario_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_14_200743) do
+ActiveRecord::Schema.define(version: 2018_11_16_234811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,13 @@ ActiveRecord::Schema.define(version: 2018_11_14_200743) do
     t.integer "version"
     t.bigint "previous_character_id"
     t.index ["previous_character_id"], name: "index_characters_on_previous_character_id"
+  end
+
+  create_table "characters_scenarios", id: false, force: :cascade do |t|
+    t.bigint "character_id", null: false
+    t.bigint "scenario_id", null: false
+    t.index ["character_id"], name: "index_characters_scenarios_on_character_id"
+    t.index ["scenario_id"], name: "index_characters_scenarios_on_scenario_id"
   end
 
   create_table "likes", force: :cascade do |t|

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -18,6 +18,24 @@ describe Character do
     end
   end
 
+  describe '#scenarios' do
+    before { character.save }
+    let!(:scenario1) { character.scenarios.create(name: 'Scenario 1')  }
+    let!(:scenario2) { character.scenarios.create(name: 'Scenario 2')  }
+    subject { character.scenarios }
+
+    it 'associates scenarios and characters' do
+      expect(subject).to include(scenario1)
+      expect(subject).to include(scenario2)
+      expect(scenario1.characters).to include(character)
+    end
+  end
+
   describe '#deactivate' do
+    subject { character.deactivate }
+    it 'should set state to inactive' do
+      subject
+      expect(character.state).to eq 'inactive'
+    end
   end
 end


### PR DESCRIPTION
Let's limit the characters to the ones that are in a particular scenario.

This will also let us show which scenarios a character has attended on the character page, but that's not this ticket.

- [x] Create a join table to establish a many-to-many relationship between characters and scenarios
- [x] Add an input on the scenario edit to add characters to a scenario
- [x] Filter Character dropdown on scenario input page