### PR TITLE
Character will stay selected

### DIFF
--- a/app/controllers/pixes_controller.rb
+++ b/app/controllers/pixes_controller.rb
@@ -72,7 +72,9 @@ class PixesController < ApplicationController
 
   def go_to_pix(pix)
     if pix.scenario
-      scenario_path pix.scenario, anchor: "pix-#{pix.id}"
+      scenario_path pix.scenario,
+                    anchor: "pix-#{pix.id}",
+                    params: { character_id: pix.character.id }
     else
       character_path pix.character, anchor: "pix-#{pix.id}"
     end

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -7,13 +7,13 @@
 <% end %>
 
 <div id="new-pix">
-  <%= form_with model: Pix.new do |f| %>
+  <%= form_with model: Pix.new(character_id: params[:character_id]) do |f| %>
     <%= f.hidden_field :scenario_id, value: @scenario.id %>
     <div class="mb-2">
       <%= f.collection_select :character_id, @scenario.characters, :id, :display_name, {}, class: 'form-control' %>
     </div>
     <div class="mb-2">
-      <%= f.text_field :msg, class: 'form-control' %>
+      <%= f.text_area :msg, class: 'form-control' %>
     </div>
     <div class="mb-2">
       <%= f.submit 'Post', type: 'submit', class: 'btn btn-outline-light' %>

--- a/spec/controllers/pixes_controller_spec.rb
+++ b/spec/controllers/pixes_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PixesController, type: :controller do
         it "redirects to the updated pix's scenario page" do
           post :create, params: valid_params
           pix = Pix.find_by(msg: 'PARTY!')
-          expect(response).to redirect_to(scenario_path(pix.scenario, anchor: "pix-#{pix.id}"))
+          expect(response).to redirect_to(scenario_path(pix.scenario, anchor: "pix-#{pix.id}", params: {character_id: pix.character.id}))
         end
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe PixesController, type: :controller do
         let(:pix) { create :pix, scenario: scenario }
 
         it "redirects to the updated pix's scenario page" do
-          expect(response).to redirect_to(scenario_path pix.scenario, anchor: "pix-#{pix.id}")
+          expect(response).to redirect_to(scenario_path pix.scenario, anchor: "pix-#{pix.id}", params: { character_id: pix.character.id})
         end
       end
     end


### PR DESCRIPTION
When we redirect from character creation back to the scenarios page, we'll keep the character as a param, and then show that character on the scenario form. Also, made the input a text area.